### PR TITLE
Fix upcoming colles

### DIFF
--- a/src/cogs/colloscope_helper/colloscope_maker.py
+++ b/src/cogs/colloscope_helper/colloscope_maker.py
@@ -346,7 +346,7 @@ def get_group_upcoming_colles(colles: list[ColleData], group: str) -> list[Colle
     colles = sort_colles(colles, sort_type="temps")  # sort by time
     today = dt.date.today() + dt.timedelta(days=-1)  # date de la veille
 
-    filtered_colles = [c for c in colles if c.group == group and c.date > today]
+    filtered_colles = [c for c in colles if c.group == group and c.date >= today]
     return filtered_colles
 
 

--- a/src/cogs/colloscope_helper/colloscope_maker.py
+++ b/src/cogs/colloscope_helper/colloscope_maker.py
@@ -346,7 +346,7 @@ def get_group_upcoming_colles(colles: list[ColleData], group: str) -> list[Colle
     colles = sort_colles(colles, sort_type="temps")  # sort by time
     today = dt.date.today() + dt.timedelta(days=-1)  # date de la veille
 
-    filtered_colles = [c for c in colles if c.group == group and c.date < today]
+    filtered_colles = [c for c in colles if c.group == group and c.date > today]
     return filtered_colles
 
 


### PR DESCRIPTION
The function used to create the list of upcoming colles currently returns a list of already passed colles, making the /colloscope prochaine_colle command quite useless