### PR TITLE
Change export extension

### DIFF
--- a/src/cogs/colloscope_helper/__init__.py
+++ b/src/cogs/colloscope_helper/__init__.py
@@ -98,6 +98,7 @@ class PlanningHelper(
             buffer = io.StringIO()
             cm.write_colles(buffer, format, filtered_colles, str(group), colloscope.holidays)
             buffer = io.BytesIO(buffer.getvalue().encode())
+            format = "csv"
         else:
             format = cast(Literal["pdf"], format)
             buffer = io.BytesIO()


### PR DESCRIPTION
Exports of agenda and todoist files must be ".csv"
