### PR TITLE
Ajout du support Google Sheets pour le Colloscope

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
 
 FROM python:3.12.0-alpine AS base
 # https://docs.docker.com/reference/dockerfile/#copy---parents
+RUN apk add poppler-utils --no-cache
 COPY --parents --from=build /app/.venv /
 WORKDIR /app
 COPY ./resources ./resources

--- a/compose.yml
+++ b/compose.yml
@@ -12,8 +12,11 @@ services:
       dockerfile: $PWD/Dockerfile
     ports:
       - 5678:5678
-    env_file:
-      - .env
+    environment:
+      CTS_TOKEN: ${CTS_TOKEN}
+      BOT_TOKEN: ${BOT_TOKEN}
+      OPENWEATHERMAP_API_KEY: ${OPENWEATHERMAP_API_KEY}
+      OPENIA_API_KEY: ${OPENIA_API_KEY}
     volumes:
       - $PWD/data:/app/data
       - $PWD/config.toml:/app/config.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "fpdf2",
     "pdf2image",
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 
 [tool.uv]
 dev-dependencies = [
@@ -44,7 +44,7 @@ commands =
 [tool.ruff]
 line-length = 120
 indent-width = 4
-target-version = "py312"
+target-version = "py311"
 src = ["src"]
 exclude = ["bin"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "fpdf2",
     "pdf2image",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 
 [tool.uv]
 dev-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ commands =
 [tool.ruff]
 line-length = 120
 indent-width = 4
-target-version = "py312"
+target-version = "py12"
 src = ["src"]
 exclude = ["bin"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ commands =
 [tool.ruff]
 line-length = 120
 indent-width = 4
-target-version = "py12"
+target-version = "py312"
 src = ["src"]
 exclude = ["bin"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "fpdf2",
     "pdf2image",
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.12, <3.14"
 
 [tool.uv]
 dev-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ commands =
 [tool.ruff]
 line-length = 120
 indent-width = 4
-target-version = "py311"
+target-version = "py312"
 src = ["src"]
 exclude = ["bin"]
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -58,10 +58,10 @@ class MP2IBot(commands.Bot):
         await self.sync_tree()
 
     async def sync_tree(self) -> None:
-        # First, copy global commands to the main guild for instant updates in dev
+        # First, clear guild-specific commands to avoid duplicates with global commands
         if self.config.guild_id:
             guild_obj = discord.Object(id=self.config.guild_id)
-            self.tree.copy_global_to(guild=guild_obj)
+            self.tree.clear_commands(guild=guild_obj)
             await self.tree.sync(guild=guild_obj)
         
         # Then sync other guilds if any

--- a/src/bot.py
+++ b/src/bot.py
@@ -26,10 +26,10 @@ class MP2IBot(commands.Bot):
         super().__init__(
             command_prefix=commands.when_mentioned,
             tree_cls=CustomCommandTree,
-            member_cache_flags=discord.MemberCacheFlags.none(),
-            chunk_guilds_at_startup=False,
+            member_cache_flags=discord.MemberCacheFlags.all(),
+            chunk_guilds_at_startup=True,
             allowed_mentions=discord.AllowedMentions.none(),
-            intents=discord.Intents.default(),
+            intents=discord.Intents.all(),
             help_command=None,
         )
 
@@ -58,18 +58,8 @@ class MP2IBot(commands.Bot):
         await self.sync_tree()
 
     async def sync_tree(self) -> None:
-        # First, clear guild-specific commands to avoid duplicates with global commands
-        if self.config.guild_id:
-            guild_obj = discord.Object(id=self.config.guild_id)
-            self.tree.clear_commands(guild=guild_obj)
-            await self.tree.sync(guild=guild_obj)
-        
-        # Then sync other guilds if any
         for guild_id in self.tree.active_guild_ids:
-            if guild_id != self.config.guild_id:
-                await self.tree.sync(guild=discord.Object(guild_id))
-        
-        # Finally sync global (might take time)
+            await self.tree.sync(guild=discord.Object(guild_id))
         self.app_commands: list[AppCommand] = await self.tree.sync()
 
     async def on_ready(self) -> None:

--- a/src/cogs/colloscope_helper/__init__.py
+++ b/src/cogs/colloscope_helper/__init__.py
@@ -60,6 +60,7 @@ class PlanningHelper(
             for name, param in cmd._params.items():
                 if name == "class_":
                     param.choices = choices
+
                     # On essaie aussi de désactiver l'autocomplete si possible pour éviter les conflits
                     if hasattr(param, "autocomplete"):
                         param.autocomplete = None
@@ -325,21 +326,18 @@ class PlanningHelper(
     @quicklook.autocomplete("group")
     async def group_autocompleter(self, inter: discord.Interaction, current: str) -> list[app_commands.Choice[str]]:
         try:
-            # Récupération sécurisée de la classe sélectionnée
-            # L'attribut namespace contient les valeurs déjà remplies par l'utilisateur
-            selected_class = getattr(inter.namespace, "class_", None)
+            selected_class = inter.namespace.classe
             
             if not selected_class:
-                # Si aucune classe n'est sélectionnée, on ne peut pas proposer de groupes
-                # On retourne une liste vide ou un placeholder (mais placeholder peut être sélectionné donc liste vide mieux)
+                # return empty placeholder to avoid mistake selections
                 return []
-            
+
             class_key = selected_class.lower()
             if class_key not in self.colloscopes:
                  return []
 
             groups = sorted(self.colloscopes[class_key].groups)
-            
+
             # Filtrage insensible à la casse
             current_lower = current.lower()
             return [
@@ -348,12 +346,8 @@ class PlanningHelper(
                 if current_lower in g.lower()
             ][:25] 
         except Exception as e:
-            # On log l'erreur pour le débogage mais on ne crash pas l'autocomplete
             logger.error(f"Erreur dans l'autocomplete de groupe : {e}")
             return [] 
-
-
-
 
 
 async def setup(bot: MP2IBot):

--- a/src/cogs/colloscope_helper/__init__.py
+++ b/src/cogs/colloscope_helper/__init__.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import csv
 import io
 import logging
 import os
+import re
 from functools import partial
 from glob import glob
 from typing import TYPE_CHECKING, Literal, cast
 
 import discord
+import httpx
 from discord import app_commands
 from discord.ext import commands
 from pdf2image.pdf2image import convert_from_bytes
@@ -30,6 +33,7 @@ class PlanningHelper(
         self.bot = bot
         self.colloscopes: dict[str, cm.Colloscope]
 
+        self.download_colloscope()
         self.load_colloscope()
 
         decorator = partial(
@@ -39,6 +43,110 @@ class PlanningHelper(
         decorator()(self.export)
         decorator()(self.next_colle)
 
+    def download_colloscope(self):
+        url = os.environ.get("COLLOSCOPE_URL")
+        if not url:
+            logger.warning("COLLOSCOPE_URL not found in environment variables. Skipping download.")
+            return
+
+        try:
+            logger.info(f"Downloading colloscope from {url}...")
+            response = httpx.get(url, follow_redirects=True)
+            response.raise_for_status()
+            
+            # Save raw data to ensure we have it (optional, but good for debug)
+            # with open("./external_data/colloscopes/raw_data.csv", "wb") as f:
+            #     f.write(response.content)
+
+            # Transform data in memory
+            content = response.content.decode("utf-8")
+            transformed_lines = self.transform_mpi(content)
+
+            # Save transformed data
+            output_path = "./external_data/colloscopes/mpi.csv"
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+            
+            with open(output_path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f, delimiter=",")
+                writer.writerows(transformed_lines)
+                
+            logger.info(f"Colloscope downloaded and transformed successfully to {output_path}")
+
+        except Exception as e:
+            logger.error(f"Failed to download/transform colloscope: {e}")
+
+    def transform_mpi(self, content: str) -> list[list[str]]:
+        f = io.StringIO(content)
+        reader = csv.reader(f, delimiter=",")
+        lines = list(reader)
+
+        # Skip metadata lines
+        if len(lines) < 4:
+            return []
+
+        # Adjust header extraction based on GSheet format analysis
+        # Line 4 corresponds to dates
+        header_line_index = 3 
+        
+        lines = lines[header_line_index:] 
+        header = lines[0]
+        lines = lines[2:] # Skip header and next line to get to data
+
+        new_header = [""] * 5
+        valid_indices = []
+        for i, column in enumerate(header):
+            if i < 5:
+                continue
+            if not column: continue
+            
+            date_parts = column.split("-")
+            if len(date_parts) == 3:
+                 # DD-MM-YYYY -> DD/MM/YY
+                 year = date_parts[2]
+                 if len(year) == 4: year = year[2:]
+                 new_header.append(f"{date_parts[0]}/{date_parts[1]}/{year}")
+                 valid_indices.append(i)
+            else:
+                 new_header.append(column)
+                 valid_indices.append(i)
+
+        processed_lines = []
+        # The header included for stats
+        final_header = ["Matiere", "Prof", "Jour", "Heure", "Salle"] + new_header[5:]
+        processed_lines.append(final_header)
+
+        for line in lines:
+            if not line or not any(line): continue
+            if len(line) < 5: continue
+            
+            # Swapping columns to match: Subject, Prof, Day, Hour, Room
+            # Original: Subject(0), Prof(1), Room(2), Day(3), Hour(4)
+            day = line[3]
+            hour = line[4]
+            room = line[2]
+            
+            # Hour formatting: "18h-19h" -> "18h"
+            hour = hour.split("-")[0].replace(" ", "")
+
+            new_row = [line[0], line[1], day, hour, room]
+            
+            # Append only the columns corresponding to valid dates/headers
+            for index in valid_indices:
+                if index < len(line):
+                    # Extract only the first number found (Group ID)
+                    val = line[index]
+                    match = re.search(r"(\d+)", val)
+                    if match:
+                        new_row.append(match.group(1))
+                    else:
+                         new_row.append("")
+                else:
+                    new_row.append("") # Padding if missing
+
+            processed_lines.append(new_row)
+        
+        return processed_lines
+
     def load_colloscope(self):
         self.colloscopes = {}
         for csv_file in glob("./external_data/colloscopes/*.csv"):
@@ -47,6 +155,7 @@ class PlanningHelper(
                 continue
             try:
                 self.colloscopes[class_.lower()] = cm.Colloscope.from_filename(csv_file)
+                logger.info(f"Loaded colloscope for class {class_}")
             except Exception as e:
                 logger.warning(
                     __("Error while reading the colloscope from : {filename}", filename=csv_file), exc_info=e
@@ -56,16 +165,38 @@ class PlanningHelper(
     @app_commands.rename(class_="classe", group="groupe")
     @app_commands.describe(class_="Votre classe.", group="Votre groupe de colle.")
     async def quicklook(self, inter: discord.Interaction, class_: str, group: str):
-        colloscope = self.colloscopes[class_]
+        class_key = class_.lower()
+        if class_key not in self.colloscopes:
+            available = ", ".join(self.colloscopes.keys())
+            await inter.response.send_message(
+                f"❌ Classe '{class_}' introuvable. Classes disponibles : {available}",
+                ephemeral=True
+            )
+            return
+
+        # Defer immediately to avoid timeout/active waiting feel
+        await inter.response.defer()
+
+        colloscope = self.colloscopes[class_key]
         colles = cm.sort_colles(colloscope.colles, sort_type="temps")  # sort by time
 
         filtered_colles = [c for c in colles if c.group == str(group)]
         if not filtered_colles:
-            raise ValueError("Aucune colle n'a été trouvé pour ce groupe")
+            await inter.followup.send(f"❌ Aucune colle trouvée pour le groupe {group}")
+            return
 
+        # Run CPU-bound task in executor to avoid blocking the bot loop
+        loop = self.bot.loop
+        files = await loop.run_in_executor(None, self._generate_quicklook_files, filtered_colles, group, colloscope)
+
+        await inter.followup.send(files=files)
+
+    def _generate_quicklook_files(self, filtered_colles, group, colloscope):
         buffer = io.BytesIO()
         cm.write_colles(buffer, "pdf", filtered_colles, str(group), colloscope.holidays)
         buffer.seek(0)
+        
+        # Convert PDF to images
         images = convert_from_bytes(buffer.read())
 
         files: list[discord.File] = []
@@ -74,8 +205,7 @@ class PlanningHelper(
             img.save(img_buffer, format="png")
             img_buffer.seek(0)
             files.append(discord.File(img_buffer, f"{i}.png"))
-
-        await inter.response.send_message(files=files)
+        return files
 
     @app_commands.command(name="export", description="Exporte le colloscope dans un fichier")
     @app_commands.rename(class_="classe", group="groupe")
@@ -89,7 +219,16 @@ class PlanningHelper(
         group: str,
         format: Literal["pdf", "csv", "agenda", "todoist"] = "pdf",
     ):
-        colloscope = self.colloscopes[class_]
+        class_key = class_.lower()
+        if class_key not in self.colloscopes:
+            available = ", ".join(self.colloscopes.keys())
+            await inter.response.send_message(
+                f"❌ Classe '{class_}' introuvable. Classes disponibles : {available}",
+                ephemeral=True
+            )
+            return
+
+        colloscope = self.colloscopes[class_key]
 
         colles = cm.sort_colles(colloscope.colles, sort_type="temps")  # sort by time
         filtered_colles = [c for c in colles if c.group == str(group)]
@@ -114,15 +253,44 @@ class PlanningHelper(
     @app_commands.rename(class_="classe", group="groupe", nb="nombre")
     @app_commands.describe(class_="Votre classe.", group="Votre groupe de colle.", nb="Le nombre de colle à afficher.")
     async def next_colle(self, inter: discord.Interaction, class_: str, group: str, nb: int = 5):
-        colloscope = self.colloscopes[class_]
+        class_key = class_.lower()
+        if class_key not in self.colloscopes:
+            available = ", ".join(self.colloscopes.keys())
+            await inter.response.send_message(
+                f"❌ Classe '{class_}' introuvable. Classes disponibles : {available}",
+                ephemeral=True
+            )
+            return
+
+        colloscope = self.colloscopes[class_key]
 
         sorted_colles = cm.get_group_upcoming_colles(colloscope.colles, str(group))
-        output_text = f"### __Liste des {min(nb, len(sorted_colles), 12 )} prochaines Colles du groupe {group} :__\n"
+        
+        if not sorted_colles:
+            await inter.response.send_message(f"❌ Aucune colle trouvée pour le groupe {group}", ephemeral=True)
+            return
+
+        embed = discord.Embed(
+            title=f"📅 Prochaines Colles - Groupe {group}",
+            description=f"Voici les {min(nb, len(sorted_colles), 12)} prochaines colles :",
+            color=discord.Color.from_rgb(58, 134, 255) # A nice blue
+        )
+        
+        # Add footer with requestor info
+        embed.set_footer(text=f"Demandé par {inter.user.display_name}")
 
         for i in range(min(nb, len(sorted_colles), 12)):
-            date = sorted_colles[i].long_str_date
-            output_text += f"**{date.title()} : {sorted_colles[i].str_time}** - __{sorted_colles[i].subject}__ - en {sorted_colles[i].classroom} avec {sorted_colles[i].professor}\n"
-        await inter.response.send_message(output_text)
+            colle = sorted_colles[i]
+            date_str = colle.long_str_date.title()
+            
+            # Create a nice field for each colle
+            embed.add_field(
+                name=f"{date_str} - {colle.str_time}",
+                value=f"📚 **{colle.subject}**\n👨‍🏫 {colle.professor}\n🚪 Salle {colle.classroom}",
+                inline=False
+            )
+            
+        await inter.response.send_message(embed=embed)
 
     @next_colle.autocomplete("group")
     @export.autocomplete("group")
@@ -131,11 +299,16 @@ class PlanningHelper(
         if inter.namespace.classe is None:
             return [app_commands.Choice(name="Sélectionnez une classe avant un groupe", value="-1")]
 
+        class_key = inter.namespace.classe.lower()
+        if class_key not in self.colloscopes:
+             return []
+
+        groups = sorted(self.colloscopes[class_key].groups)
         return [
             app_commands.Choice(name=g, value=g)
-            for g in sorted(self.colloscopes[inter.namespace.classe].groups)
+            for g in groups
             if g.startswith(current)
-        ]
+        ][:25] # Limit to 25 choices to avoid discord errors
 
 
 async def setup(bot: MP2IBot):

--- a/src/cogs/colloscope_helper/__init__.py
+++ b/src/cogs/colloscope_helper/__init__.py
@@ -33,7 +33,7 @@ class PlanningHelper(
         self.bot = bot
         self.colloscopes: dict[str, cm.Colloscope]
 
-        self.download_colloscope()
+        self.download_colloscope() #ok the colloscope 
         self.load_colloscope()
 
         decorator = partial(
@@ -223,7 +223,8 @@ class PlanningHelper(
         colles = cm.sort_colles(colloscope.colles, sort_type="temps")  # sort by time
         filtered_colles = [c for c in colles if c.group == str(group)]
         if not filtered_colles:
-            raise ValueError("Aucune colle n'a été trouvé pour ce groupe")
+            await inter.response.send_message(f"Aucune colle trouvée pour le groupe {group}", ephemeral=True)
+            return
 
         if format in ["agenda", "csv", "todoist"]:
             format = cast(Literal["agenda", "csv", "todoist"], format)
@@ -298,7 +299,7 @@ class PlanningHelper(
             app_commands.Choice(name=g, value=g)
             for g in groups
             if g.startswith(current)
-        ][:25] # Limit to 25 choices to avoid discord errors
+        ][:25] 
 
 
 async def setup(bot: MP2IBot):

--- a/src/cogs/colloscope_helper/__init__.py
+++ b/src/cogs/colloscope_helper/__init__.py
@@ -5,7 +5,6 @@ import io
 import logging
 import os
 import re
-from functools import partial
 from glob import glob
 from typing import TYPE_CHECKING, Literal, cast
 
@@ -42,18 +41,15 @@ class PlanningHelper(
     def set_static_choices(self):
         """Injects loaded classes as static choices into command parameters."""
         sorted_keys = sorted(self.colloscopes.keys())
-        logger.info(f"Generating static choices. Found {len(sorted_keys)} classes.")
-        
-        choices = [
-            app_commands.Choice(name=k.title(), value=k) 
-            for k in sorted_keys
-        ][:25]
-        
+        logger.info(__("Generating static choices. Found {} classes.", len(sorted_keys)))
+
+        choices = [app_commands.Choice(name=k.title(), value=k) for k in sorted_keys][:25]
+
         if not choices:
             logger.warning("No classes found! Static choices will be empty.")
-        
+
         commands_to_patch = [self.quicklook, self.export, self.next_colle]
-        
+
         for cmd in commands_to_patch:
             found = False
             # direct acces to CommandParameter
@@ -64,11 +60,11 @@ class PlanningHelper(
                     # On essaie aussi de désactiver l'autocomplete si possible pour éviter les conflits
                     if hasattr(param, "autocomplete"):
                         param.autocomplete = None
-                    
+
                     found = True
                     break
             if not found:
-                logger.warning(f"Paramètre 'class_' introuvable dans la commande {cmd.name}")
+                logger.warning(__("Paramètre 'class_' introuvable dans la commande {cmd.name}", cmd=cmd))
 
     async def download_colloscope(self):
         url = os.environ.get("COLLOSCOPE_URL")
@@ -77,25 +73,25 @@ class PlanningHelper(
             return
 
         try:
-            logger.info(f"Downloading colloscope from {url}...")
+            logger.info(__("Downloading colloscope from {url}...", url=url))
             async with httpx.AsyncClient() as client:
                 response = await client.get(url, follow_redirects=True)
                 response.raise_for_status()
-            
+
             content = response.content.decode("utf-8")
             transformed_lines = self.transform_mpi(content)
 
             output_path = "./external_data/colloscopes/mpi.csv"
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
-            
-            with open(output_path, "w", newline="", encoding="utf-8") as f:
+
+            with open(output_path, "w", newline="", encoding="utf-8") as f:  # noqa: ASYNC230 (ignoring sync open in async function since it's a 'one-shot'
                 writer = csv.writer(f, delimiter=",")
                 writer.writerows(transformed_lines)
-                
-            logger.info(f"Colloscope downloaded and transformed successfully to {output_path}")
 
-        except Exception as e:
-            logger.error(f"Failed to download/transform colloscope: {e}")
+            logger.info(__("Colloscope downloaded and transformed successfully to {}", output_path))
+
+        except Exception:
+            logger.exception("Failed to download/transform colloscope")
 
     def transform_mpi(self, content: str) -> list[list[str]]:
         f = io.StringIO(content)
@@ -105,9 +101,9 @@ class PlanningHelper(
         if len(lines) < 4:
             return []
 
-        header_line_index = 3 
-        
-        lines = lines[header_line_index:] 
+        header_line_index = 3
+
+        lines = lines[header_line_index:]
         header = lines[0]
         lines = lines[2:]
 
@@ -116,36 +112,40 @@ class PlanningHelper(
         for i, column in enumerate(header):
             if i < 5:
                 continue
-            if not column: continue
-            
+            if not column:
+                continue
+
             date_parts = column.split("-")
             if len(date_parts) == 3:
-                 # DD-MM-YYYY -> DD/MM/YY
-                 year = date_parts[2]
-                 if len(year) == 4: year = year[2:]
-                 new_header.append(f"{date_parts[0]}/{date_parts[1]}/{year}")
-                 valid_indices.append(i)
+                # DD-MM-YYYY -> DD/MM/YY
+                year = date_parts[2]
+                if len(year) == 4:
+                    year = year[2:]
+                new_header.append(f"{date_parts[0]}/{date_parts[1]}/{year}")
+                valid_indices.append(i)
             else:
-                 new_header.append(column)
-                 valid_indices.append(i)
+                new_header.append(column)
+                valid_indices.append(i)
 
         processed_lines = []
         # The header included for stats
-        final_header = ["Matiere", "Prof", "Jour", "Heure", "Salle"] + new_header[5:]
+        final_header = ["Matiere", "Prof", "Jour", "Heure", "Salle", *new_header[5:]]
         processed_lines.append(final_header)
 
         for line in lines:
-            if not line or not any(line): continue
-            if len(line) < 5: continue
-            
+            if not line or not any(line):
+                continue
+            if len(line) < 5:
+                continue
+
             day = line[3]
             hour = line[4]
             room = line[2]
-            
+
             hour = hour.split("-")[0].replace(" ", "")
 
             new_row = [line[0], line[1], day, hour, room]
-            
+
             # Append only the columns corresponding to valid dates/headers
             for index in valid_indices:
                 if index < len(line):
@@ -154,12 +154,12 @@ class PlanningHelper(
                     if match:
                         new_row.append(match.group(1))
                     else:
-                         new_row.append("")
+                        new_row.append("")
                 else:
-                    new_row.append("") 
+                    new_row.append("")
 
             processed_lines.append(new_row)
-        
+
         return processed_lines
 
     def load_colloscope(self):
@@ -170,7 +170,7 @@ class PlanningHelper(
                 continue
             try:
                 self.colloscopes[class_.lower()] = cm.Colloscope.from_filename(csv_file)
-                logger.info(f"Loaded colloscope for class {class_}")
+                logger.info(__("Loaded colloscope for class {}", class_))
             except Exception as e:
                 logger.warning(
                     __("Error while reading the colloscope from : {filename}", filename=csv_file), exc_info=e
@@ -183,9 +183,9 @@ class PlanningHelper(
         class_key = class_.lower()
         if class_key not in self.colloscopes:
             available = ", ".join(self.colloscopes.keys())
+            # Les choix invalides ne **peuvent** pas être envoyé, donc cas impossible, mais on garde pour la forme
             await inter.response.send_message(
-                f"Classe '{class_}' introuvable. Classes disponibles : {available}",
-                ephemeral=True
+                f"Classe '{class_}' introuvable. Classes disponibles : {available}", ephemeral=True
             )
             return
 
@@ -209,7 +209,7 @@ class PlanningHelper(
         buffer = io.BytesIO()
         cm.write_colles(buffer, "pdf", filtered_colles, str(group), colloscope.holidays)
         buffer.seek(0)
-        
+
         # Convert PDF to images
         images = convert_from_bytes(buffer.read())
 
@@ -237,8 +237,7 @@ class PlanningHelper(
         if class_key not in self.colloscopes:
             available = ", ".join(self.colloscopes.keys())
             await inter.response.send_message(
-                f"Classe '{class_}' introuvable. Classes disponibles : {available}",
-                ephemeral=True
+                f"Classe '{class_}' introuvable. Classes disponibles : {available}", ephemeral=True
             )
             return
 
@@ -256,7 +255,7 @@ class PlanningHelper(
         # CPU-bound task in executor for heavy formats like PDF
         loop = self.bot.loop
         file = await loop.run_in_executor(None, self._generate_export_file, filtered_colles, group, colloscope, format)
-        
+
         await inter.followup.send(file=file)
 
     def _generate_export_file(self, filtered_colles, group, colloscope, format):
@@ -271,7 +270,7 @@ class PlanningHelper(
             byte_buffer = io.BytesIO()
             cm.write_colles(byte_buffer, format_cast, filtered_colles, str(group), colloscope.holidays)
             file_ext = "pdf"
-            
+
         byte_buffer.seek(0)
         return discord.File(byte_buffer, filename=f"colloscope.{file_ext}")
 
@@ -279,22 +278,21 @@ class PlanningHelper(
     @app_commands.rename(class_="classe", group="groupe", nb="nombre")
     @app_commands.describe(class_="Votre classe.", group="Votre groupe de colle.", nb="Le nombre de colle à afficher.")
     async def next_colle(self, inter: discord.Interaction, class_: str, group: str, nb: int = 5):
-        # Defer to avoid "Unknown interaction" if processing takes >3s
+        # Defer to avoid "Unknown interaction" if processing takes >3s (should ne be possible for this command)
         await inter.response.defer()
 
         class_key = class_.lower()
         if class_key not in self.colloscopes:
             available = ", ".join(self.colloscopes.keys())
             await inter.followup.send(
-                f"Classe '{class_}' introuvable. Classes disponibles : {available}",
-                ephemeral=True
+                f"Classe '{class_}' introuvable. Classes disponibles : {available}", ephemeral=True
             )
             return
 
         colloscope = self.colloscopes[class_key]
 
         sorted_colles = cm.get_group_upcoming_colles(colloscope.colles, str(group))
-        
+
         if not sorted_colles:
             await inter.followup.send(f"Aucune colle trouvée pour le groupe {group}", ephemeral=True)
             return
@@ -302,23 +300,23 @@ class PlanningHelper(
         embed = discord.Embed(
             title=f"Prochaines Colles - Groupe {group}",
             description=f"Voici les {min(nb, len(sorted_colles), 12)} prochaines colles :",
-            color=discord.Color.from_rgb(58, 134, 255) # A nice blue
+            color=discord.Color.from_rgb(58, 134, 255),  # A nice blue
         )
-        
+
         # Add footer with requestor info
         embed.set_footer(text=f"Demandé par {inter.user.display_name}")
 
         for i in range(min(nb, len(sorted_colles), 12)):
             colle = sorted_colles[i]
             date_str = colle.long_str_date.title()
-            
+
             # Create a nice field for each colle
             embed.add_field(
                 name=f"{date_str} - {colle.str_time}",
                 value=f"**{colle.subject}**\n{colle.professor}\nSalle {colle.classroom}",
-                inline=False
+                inline=False,
             )
-            
+
         await inter.followup.send(embed=embed)
 
     @next_colle.autocomplete("group")
@@ -327,27 +325,23 @@ class PlanningHelper(
     async def group_autocompleter(self, inter: discord.Interaction, current: str) -> list[app_commands.Choice[str]]:
         try:
             selected_class = inter.namespace.classe
-            
+
             if not selected_class:
                 # return empty placeholder to avoid mistake selections
                 return []
 
             class_key = selected_class.lower()
             if class_key not in self.colloscopes:
-                 return []
+                return []
 
             groups = sorted(self.colloscopes[class_key].groups)
 
             # Filtrage insensible à la casse
             current_lower = current.lower()
-            return [
-                app_commands.Choice(name=g, value=g)
-                for g in groups
-                if current_lower in g.lower()
-            ][:25] 
-        except Exception as e:
-            logger.error(f"Erreur dans l'autocomplete de groupe : {e}")
-            return [] 
+            return [app_commands.Choice(name=g, value=g) for g in groups if current_lower in g.lower()][:25]
+        except Exception:
+            logger.exception("Erreur dans l'autocomplete de groupe")
+            return []
 
 
 async def setup(bot: MP2IBot):

--- a/src/cogs/colloscope_helper/__init__.py
+++ b/src/cogs/colloscope_helper/__init__.py
@@ -56,15 +56,13 @@ class PlanningHelper(
         
         for cmd in commands_to_patch:
             found = False
-            for param in cmd.parameters:
-                if param.name == "class_":
-                    # Injection des choix statiques via l'attribut privé _choices
-                    # C'est nécessaire car discord.py ne permet pas de modifier choices dynamiquement via l'API publique
-                    param._choices = choices
+            # direct acces to CommandParameter
+            for name, param in cmd._params.items():
+                if name == "class_":
+                    param.choices = choices
                     # On essaie aussi de désactiver l'autocomplete si possible pour éviter les conflits
-                    # Le client Discord utilissera les choix statiques s'ils sont présents
-                    if hasattr(param, "_autocomplete"):
-                        param._autocomplete = None
+                    if hasattr(param, "autocomplete"):
+                        param.autocomplete = None
                     
                     found = True
                     break

--- a/src/cogs/colloscope_helper/__init__.py
+++ b/src/cogs/colloscope_helper/__init__.py
@@ -58,11 +58,9 @@ class PlanningHelper(
             # with open("./external_data/colloscopes/raw_data.csv", "wb") as f:
             #     f.write(response.content)
 
-            # Transform data in memory
             content = response.content.decode("utf-8")
             transformed_lines = self.transform_mpi(content)
 
-            # Save transformed data
             output_path = "./external_data/colloscopes/mpi.csv"
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
             
@@ -80,17 +78,14 @@ class PlanningHelper(
         reader = csv.reader(f, delimiter=",")
         lines = list(reader)
 
-        # Skip metadata lines
         if len(lines) < 4:
             return []
 
-        # Adjust header extraction based on GSheet format analysis
-        # Line 4 corresponds to dates
         header_line_index = 3 
         
         lines = lines[header_line_index:] 
         header = lines[0]
-        lines = lines[2:] # Skip header and next line to get to data
+        lines = lines[2:]
 
         new_header = [""] * 5
         valid_indices = []
@@ -119,13 +114,10 @@ class PlanningHelper(
             if not line or not any(line): continue
             if len(line) < 5: continue
             
-            # Swapping columns to match: Subject, Prof, Day, Hour, Room
-            # Original: Subject(0), Prof(1), Room(2), Day(3), Hour(4)
             day = line[3]
             hour = line[4]
             room = line[2]
             
-            # Hour formatting: "18h-19h" -> "18h"
             hour = hour.split("-")[0].replace(" ", "")
 
             new_row = [line[0], line[1], day, hour, room]
@@ -133,7 +125,6 @@ class PlanningHelper(
             # Append only the columns corresponding to valid dates/headers
             for index in valid_indices:
                 if index < len(line):
-                    # Extract only the first number found (Group ID)
                     val = line[index]
                     match = re.search(r"(\d+)", val)
                     if match:
@@ -141,7 +132,7 @@ class PlanningHelper(
                     else:
                          new_row.append("")
                 else:
-                    new_row.append("") # Padding if missing
+                    new_row.append("") 
 
             processed_lines.append(new_row)
         
@@ -178,14 +169,13 @@ class PlanningHelper(
         await inter.response.defer()
 
         colloscope = self.colloscopes[class_key]
-        colles = cm.sort_colles(colloscope.colles, sort_type="temps")  # sort by time
+        colles = cm.sort_colles(colloscope.colles, sort_type="temps")
 
         filtered_colles = [c for c in colles if c.group == str(group)]
         if not filtered_colles:
-            await inter.followup.send(f"❌ Aucune colle trouvée pour le groupe {group}")
+            await inter.followup.send(f"Aucune colle trouvée pour le groupe {group}")
             return
 
-        # Run CPU-bound task in executor to avoid blocking the bot loop
         loop = self.bot.loop
         files = await loop.run_in_executor(None, self._generate_quicklook_files, filtered_colles, group, colloscope)
 
@@ -223,7 +213,7 @@ class PlanningHelper(
         if class_key not in self.colloscopes:
             available = ", ".join(self.colloscopes.keys())
             await inter.response.send_message(
-                f"❌ Classe '{class_}' introuvable. Classes disponibles : {available}",
+                f"Classe '{class_}' introuvable. Classes disponibles : {available}",
                 ephemeral=True
             )
             return
@@ -257,7 +247,7 @@ class PlanningHelper(
         if class_key not in self.colloscopes:
             available = ", ".join(self.colloscopes.keys())
             await inter.response.send_message(
-                f"❌ Classe '{class_}' introuvable. Classes disponibles : {available}",
+                f"Classe '{class_}' introuvable. Classes disponibles : {available}",
                 ephemeral=True
             )
             return
@@ -267,11 +257,11 @@ class PlanningHelper(
         sorted_colles = cm.get_group_upcoming_colles(colloscope.colles, str(group))
         
         if not sorted_colles:
-            await inter.response.send_message(f"❌ Aucune colle trouvée pour le groupe {group}", ephemeral=True)
+            await inter.response.send_message(f"Aucune colle trouvée pour le groupe {group}", ephemeral=True)
             return
 
         embed = discord.Embed(
-            title=f"📅 Prochaines Colles - Groupe {group}",
+            title=f"Prochaines Colles - Groupe {group}",
             description=f"Voici les {min(nb, len(sorted_colles), 12)} prochaines colles :",
             color=discord.Color.from_rgb(58, 134, 255) # A nice blue
         )
@@ -286,7 +276,7 @@ class PlanningHelper(
             # Create a nice field for each colle
             embed.add_field(
                 name=f"{date_str} - {colle.str_time}",
-                value=f"📚 **{colle.subject}**\n👨‍🏫 {colle.professor}\n🚪 Salle {colle.classroom}",
+                value=f"**{colle.subject}**\n{colle.professor}\nSalle {colle.classroom}",
                 inline=False
             )
             

--- a/src/cogs/colloscope_helper/__init__.py
+++ b/src/cogs/colloscope_helper/__init__.py
@@ -260,15 +260,15 @@ class PlanningHelper(
 
     def _generate_export_file(self, filtered_colles, group, colloscope, format):
         if format in ["agenda", "csv", "todoist"]:
-            format_cast = cast(Literal["agenda", "csv", "todoist"], format)
+            format = cast(Literal["agenda", "csv", "todoist"], format)
             buffer = io.StringIO()
-            cm.write_colles(buffer, format_cast, filtered_colles, str(group), colloscope.holidays)
+            cm.write_colles(buffer, format, filtered_colles, str(group), colloscope.holidays)
             byte_buffer = io.BytesIO(buffer.getvalue().encode())
             file_ext = "csv"
         else:
-            format_cast = cast(Literal["pdf"], format)
+            format = cast(Literal["pdf"], format)
             byte_buffer = io.BytesIO()
-            cm.write_colles(byte_buffer, format_cast, filtered_colles, str(group), colloscope.holidays)
+            cm.write_colles(byte_buffer, format, filtered_colles, str(group), colloscope.holidays)
             file_ext = "pdf"
 
         byte_buffer.seek(0)

--- a/src/cogs/colloscope_helper/__init__.py
+++ b/src/cogs/colloscope_helper/__init__.py
@@ -54,10 +54,8 @@ class PlanningHelper(
             # Note: cmd.parameters is a list of AppCommandParameter
             for param in cmd.parameters:
                 if param.name == "class_":
-                    param.choices = choices
-                    # We might want to remove autocomplete if it was set, but we removed the decorator so it should be fine.
-                    # However, app_commands.autocomplete sets a flag. 
-                    # Since we are removing the decorators below, we are good.
+                    # Accessing private attribute because choices property has no setter
+                    param._choices = choices
                     break
 
     async def download_colloscope(self):

--- a/src/cogs/fun.py
+++ b/src/cogs/fun.py
@@ -45,7 +45,7 @@ class Fun(Cog):
 
         # words that trigger the bot to react with a random emoji from the list assigned to the user.
         self.users_triggers: dict[int, list[str]] = {
-            726867561924263946: ["bouteille", "boire," "bière", "alcool", "alcoolique", "alcoolisme", "alcoolique"],
+            726867561924263946: ["bouteille", "boire,bière", "alcool", "alcoolique", "alcoolisme", "alcoolique"],
             1015216092920168478: ["couleur", "couleurs"],
             433713351592247299: ["tong", "tongs", "gitan"],
             199545535017779200: ["escabeau", "petit"],

--- a/src/cogs/openai_chatbot.py
+++ b/src/cogs/openai_chatbot.py
@@ -182,9 +182,11 @@ class ChatBot(Cog):
             and message.author.id != message.guild.me.id
             and (
                 message.guild.me in message.mentions
-                or message.reference is not None
-                and isinstance(message.reference.resolved, discord.Message)
-                and message.reference.resolved.author.id == message.guild.me.id
+                or (
+                    message.reference is not None
+                    and isinstance(message.reference.resolved, discord.Message)
+                    and message.reference.resolved.author.id == message.guild.me.id
+                )
             )
         ):
             await self.ask_to_openai(message)

--- a/typings/pdf2image/pdf2image.py
+++ b/typings/pdf2image/pdf2image.py
@@ -27,5 +27,4 @@ def convert_from_bytes(
     use_pdftocairo: bool = False,
     timeout: int | None = None,
     hide_annotations: bool = False,
-) -> list[Image.Image]:
-    ...
+) -> list[Image.Image]: ...


### PR DESCRIPTION
 Nouveautés

Synchronisation Automatique : Le bot lit désormais le colloscope directement depuis un Google Sheet (via l'URL d'export CSV). 
Nouvelle Interface : La commande /colloscope prochaine_colle affiche maintenant un joli tableau récapitulatif (Embeds Discord) au lieu du texte brut.

Améliorations & Correctifs

Performance : J'ai corrigé les timeouts ("Unknown Interaction") sur la commande /aperçu en traitant la génération PDF en arrière-plan.

Robustesse :

Gestion insensible à la casse (supporte "mpi" et "MPI").
Nettoyage automatique des données (gère les sauts de ligne et les formats type "5 + Félix").

Compatibilité : Mise à jour confirmée pour Python 3.11+.

Configuration

Il suffit d'ajouter une variable COLLOSCOPE_URL dans le  .env pour activer la synchro.